### PR TITLE
Feature: JWT Authentication- Login and Logout with BCrypt password verification

### DIFF
--- a/backend/FlashIdBackend/Application/Common/Interfaces/IAuthService.cs
+++ b/backend/FlashIdBackend/Application/Common/Interfaces/IAuthService.cs
@@ -1,0 +1,9 @@
+using Application.Features.Auth.DTOs;
+
+namespace Application.Common.Interfaces;
+
+public interface IAuthService
+{
+    Task<LoginResponseDto> LoginAsync(LoginRequestDto request, string ipAddress);
+    Task<LogoutResponseDto> LogoutAsync(Guid userId, string ipAddress);
+}

--- a/backend/FlashIdBackend/Application/Features/Auth/DTOs/AuthDto.cs
+++ b/backend/FlashIdBackend/Application/Features/Auth/DTOs/AuthDto.cs
@@ -1,0 +1,22 @@
+namespace Application.Features.Auth.DTOs;
+
+public class LoginRequestDto
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}
+
+public class LoginResponseDto
+{
+    public string Token { get; set; } = string.Empty;
+    public DateTime ExpiresAt { get; set; }
+    public Guid UserId { get; set; }
+    public string Role { get; set; } = string.Empty;
+    public string Names { get; set; } = string.Empty;
+    public string Surname { get; set; } = string.Empty;
+}
+
+public class LogoutResponseDto
+{
+    public string Message { get; set; } = string.Empty;
+}

--- a/backend/FlashIdBackend/Domain/Enums/AuditEventType.cs
+++ b/backend/FlashIdBackend/Domain/Enums/AuditEventType.cs
@@ -4,6 +4,7 @@ public enum AuditEventType
 {
     UserRegistered,
     UserLoggedIn,
+    UserLoggedOut,
     FailedLoginAttempt,
     CredentialIssued,
     CredentialRevoked,

--- a/backend/FlashIdBackend/Infrastructure/Data/DbSeeder.cs
+++ b/backend/FlashIdBackend/Infrastructure/Data/DbSeeder.cs
@@ -355,7 +355,7 @@ public static class DbSeeder
                 Email = email,
                 PhoneNumber = phone,
                 Username = username,
-                PasswordHash = "password123",
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword("password123"),
                 FailedLoginAttempts = 0,
                 LockoutUntil = null,
                 LastLoginAt = null,

--- a/backend/FlashIdBackend/Infrastructure/DependencyInjection.cs
+++ b/backend/FlashIdBackend/Infrastructure/DependencyInjection.cs
@@ -1,0 +1,17 @@
+using Application.Common.Interfaces;
+using Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services
+    )
+    {
+        services.AddScoped<IAuthService, AuthService>();
+
+        return services;
+    }
+}

--- a/backend/FlashIdBackend/Infrastructure/Infrastructure.csproj
+++ b/backend/FlashIdBackend/Infrastructure/Infrastructure.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="BCrypt.Net-Next" Version="4.2.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7" />

--- a/backend/FlashIdBackend/Infrastructure/Services/AuthService.cs
+++ b/backend/FlashIdBackend/Infrastructure/Services/AuthService.cs
@@ -34,7 +34,7 @@ public class AuthService : IAuthService
             throw new UnauthorizedAccessException("Password is required.");
 
         var user = await _context.DomainUsers.FirstOrDefaultAsync(u =>
-            u.Email == request.Email
+            u.Email.ToLower() == request.Email.ToLower()
         );
 
         if (user == null)
@@ -89,8 +89,7 @@ public class AuthService : IAuthService
         _context.AuditLogs.Add(auditLog);
         await _context.SaveChangesAsync();
 
-        var token = GenerateJwtToken(user);
-        var expiresAt = DateTime.UtcNow.AddHours(8);
+        var (token, expiresAt) = GenerateJwtToken(user);
 
         return new LoginResponseDto
         {
@@ -112,7 +111,7 @@ public class AuthService : IAuthService
             var auditLog = new Domain.Entities.AuditLog
             {
                 Id = Guid.NewGuid(),
-                EventType = AuditEventType.UserLoggedIn,
+                EventType = AuditEventType.UserLoggedOut,
                 Details = $"User {user.Email} logged out.",
                 IpAddress = ipAddress,
                 ActorId = user.Id,
@@ -125,7 +124,7 @@ public class AuthService : IAuthService
         return new LogoutResponseDto { Message = "Logged out successfully." };
     }
 
-    private string GenerateJwtToken(Domain.Entities.User user)
+    private (string token, DateTime expiresAt) GenerateJwtToken(Domain.Entities.User user)
     {
         var jwtKey =
             _configuration["Jwt:Key"]
@@ -133,6 +132,7 @@ public class AuthService : IAuthService
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var expiresAt = DateTime.UtcNow.AddHours(8);
 
         var claims = new[]
         {
@@ -147,10 +147,10 @@ public class AuthService : IAuthService
             issuer: _configuration["Jwt:Issuer"],
             audience: _configuration["Jwt:Audience"],
             claims: claims,
-            expires: DateTime.UtcNow.AddHours(8),
+            expires: expiresAt,
             signingCredentials: credentials
         );
 
-        return new JwtSecurityTokenHandler().WriteToken(token);
+        return (new JwtSecurityTokenHandler().WriteToken(token), expiresAt);
     }
 }

--- a/backend/FlashIdBackend/Infrastructure/Services/AuthService.cs
+++ b/backend/FlashIdBackend/Infrastructure/Services/AuthService.cs
@@ -1,0 +1,156 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Application.Common.Interfaces;
+using Application.Features.Auth.DTOs;
+using Domain.Enums;
+using Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Infrastructure.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly AppDbContext _context;
+    private readonly IConfiguration _configuration;
+
+    public AuthService(AppDbContext context, IConfiguration configuration)
+    {
+        _context = context;
+        _configuration = configuration;
+    }
+
+    public async Task<LoginResponseDto> LoginAsync(
+        LoginRequestDto request,
+        string ipAddress
+    )
+    {
+        if (string.IsNullOrWhiteSpace(request.Email))
+            throw new UnauthorizedAccessException("Email is required.");
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+            throw new UnauthorizedAccessException("Password is required.");
+
+        var user = await _context.DomainUsers.FirstOrDefaultAsync(u =>
+            u.Email == request.Email
+        );
+
+        if (user == null)
+            throw new UnauthorizedAccessException("Invalid email or password.");
+
+        if (user.IsDeleted)
+            throw new UnauthorizedAccessException("This account has been deleted.");
+
+        if (user.LockoutUntil.HasValue && user.LockoutUntil > DateTime.UtcNow)
+            throw new UnauthorizedAccessException(
+                $"Account is locked until {user.LockoutUntil.Value:yyyy-MM-dd HH:mm} UTC."
+            );
+
+        if (!BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
+        {
+            user.FailedLoginAttempts++;
+
+            if (user.FailedLoginAttempts >= 5)
+                user.LockoutUntil = DateTime.UtcNow.AddMinutes(30);
+
+            _context.DomainUsers.Update(user);
+
+            var failedLog = new Domain.Entities.AuditLog
+            {
+                Id = Guid.NewGuid(),
+                EventType = AuditEventType.FailedLoginAttempt,
+                Details = $"Failed login attempt for {request.Email}.",
+                IpAddress = ipAddress,
+                ActorId = user.Id,
+                CreatedAt = DateTime.UtcNow,
+            };
+            _context.AuditLogs.Add(failedLog);
+            await _context.SaveChangesAsync();
+
+            throw new UnauthorizedAccessException("Invalid email or password.");
+        }
+
+        user.FailedLoginAttempts = 0;
+        user.LockoutUntil = null;
+        user.LastLoginAt = DateTime.UtcNow;
+        _context.DomainUsers.Update(user);
+
+        var auditLog = new Domain.Entities.AuditLog
+        {
+            Id = Guid.NewGuid(),
+            EventType = AuditEventType.UserLoggedIn,
+            Details = $"User {user.Email} logged in successfully.",
+            IpAddress = ipAddress,
+            ActorId = user.Id,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _context.AuditLogs.Add(auditLog);
+        await _context.SaveChangesAsync();
+
+        var token = GenerateJwtToken(user);
+        var expiresAt = DateTime.UtcNow.AddHours(8);
+
+        return new LoginResponseDto
+        {
+            Token = token,
+            ExpiresAt = expiresAt,
+            UserId = user.Id,
+            Role = user.Role.ToString(),
+            Names = user.Names,
+            Surname = user.Surname,
+        };
+    }
+
+    public async Task<LogoutResponseDto> LogoutAsync(Guid userId, string ipAddress)
+    {
+        var user = await _context.DomainUsers.FirstOrDefaultAsync(u => u.Id == userId);
+
+        if (user != null)
+        {
+            var auditLog = new Domain.Entities.AuditLog
+            {
+                Id = Guid.NewGuid(),
+                EventType = AuditEventType.UserLoggedIn,
+                Details = $"User {user.Email} logged out.",
+                IpAddress = ipAddress,
+                ActorId = user.Id,
+                CreatedAt = DateTime.UtcNow,
+            };
+            _context.AuditLogs.Add(auditLog);
+            await _context.SaveChangesAsync();
+        }
+
+        return new LogoutResponseDto { Message = "Logged out successfully." };
+    }
+
+    private string GenerateJwtToken(Domain.Entities.User user)
+    {
+        var jwtKey =
+            _configuration["Jwt:Key"]
+            ?? throw new InvalidOperationException("JWT key is not configured.");
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, user.Email),
+            new Claim(ClaimTypes.Role, user.Role.ToString()),
+            new Claim("userId", user.Id.ToString()),
+            new Claim("role", user.Role.ToString()),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(8),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/backend/FlashIdBackend/Presentation/Controllers/AuthController.cs
+++ b/backend/FlashIdBackend/Presentation/Controllers/AuthController.cs
@@ -1,0 +1,58 @@
+using Application.Common.Interfaces;
+using Application.Features.Auth.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Presentation.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+
+    public AuthController(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
+    {
+        try
+        {
+            var ipAddress =
+                HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var result = await _authService.LoginAsync(request, ipAddress);
+            return Ok(result);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { error = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { error = "An unexpected error occurred." });
+        }
+    }
+
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        try
+        {
+            var userIdClaim = User.FindFirst("userId")?.Value;
+            if (userIdClaim == null)
+                return Unauthorized(new { error = "Invalid token." });
+
+            var userId = Guid.Parse(userIdClaim);
+            var ipAddress =
+                HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var result = await _authService.LogoutAsync(userId, ipAddress);
+            return Ok(result);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { error = "An unexpected error occurred." });
+        }
+    }
+}

--- a/backend/FlashIdBackend/Presentation/Controllers/AuthController.cs
+++ b/backend/FlashIdBackend/Presentation/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Application.Common.Interfaces;
 using Application.Features.Auth.DTOs;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Presentation.Controllers;
@@ -35,6 +36,7 @@ public class AuthController : ControllerBase
         }
     }
 
+    [Authorize]
     [HttpPost("logout")]
     public async Task<IActionResult> Logout()
     {

--- a/backend/FlashIdBackend/Presentation/Presentation.csproj
+++ b/backend/FlashIdBackend/Presentation/Presentation.csproj
@@ -8,9 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/FlashIdBackend/Presentation/Program.cs
+++ b/backend/FlashIdBackend/Presentation/Program.cs
@@ -1,54 +1,49 @@
+using System.Text;
+using Infrastructure;
 using Infrastructure.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+builder.Services.AddInfrastructure();
+
+builder.Services.AddControllers();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!)
+            ),
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
 
-// seed the db on startup
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     await DbSeeder.SeedAsync(db);
 }
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
-
 app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-    {
-        var forecast = Enumerable.Range(1, 5).Select(index =>
-                new WeatherForecast
-                (
-                    DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                    Random.Shared.Next(-20, 55),
-                    summaries[Random.Shared.Next(summaries.Length)]
-                ))
-            .ToArray();
-        return forecast;
-    })
-    .WithName("GetWeatherForecast");
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/backend/FlashIdBackend/Presentation/appsettings.Development.json
+++ b/backend/FlashIdBackend/Presentation/appsettings.Development.json
@@ -1,11 +1,7 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=FlashIdDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Jwt": {
+    "Key": "FlashID-Super-Secret-Key-2026-TechTitans-COS301-Capstone-Project",
+    "Issuer": "FlashID",
+    "Audience": "FlashID-Users"
   }
 }

--- a/backend/FlashIdBackend/Presentation/appsettings.json
+++ b/backend/FlashIdBackend/Presentation/appsettings.json
@@ -2,6 +2,11 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=FlashIdDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
   },
+  "Jwt": {
+    "Key": "FlashID-Super-Secret-Key-2026-TechTitans-COS301-Capstone-Project",
+    "Issuer": "FlashID",
+    "Audience": "FlashID-Users"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/backend/FlashIdBackend/Presentation/appsettings.json
+++ b/backend/FlashIdBackend/Presentation/appsettings.json
@@ -2,11 +2,6 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=FlashIdDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
   },
-  "Jwt": {
-    "Key": "FlashID-Super-Secret-Key-2026-TechTitans-COS301-Capstone-Project",
-    "Issuer": "FlashID",
-    "Audience": "FlashID-Users"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Implements JWT-based authentication for all user roles (Citizen, Official, GovernmentAdministrator).

Changes

Application Layer
- AuthDto.cs-  LoginRequestDto, LoginResponseDto, LogoutResponseDto
- IAuthService- interface with LoginAsync and LogoutAsync

Infrastructure Layer
- AuthService - full JWT login and logout implementation:
  - BCrypt password verification
  - Account lockout after 5 failed attempts (30 min lockout)
  - JWT token generation with userId and role claims
  - AuditLog entries for login and logout events
- DependencyInjection.cs- AuthService registered
- DbSeeder.cs - passwords now BCrypt hashed
- BCrypt.Net-Next package added

 Presentation Layer
- AuthController -POST /api/auth/login and POST /api/auth/logout
- Program.cs - JWT middleware configured
- appsettings.json - JWT key, issuer, audience added

Tested
- Login tested locally with seeded GovernmentAdministrator user
- Returns valid JWT token with correct role, userId, names and surname
- Token verified to contain correct claims

Please note
- All seeded users use password: password123
- Token expires after 8 hours
- Logout is stateless -client must discard the token