### PR TITLE
Tests: Institution validator, service, and form tests with TESTING.md

### DIFF
--- a/backend/FlashIdBackend/tests/InstitutionValidatorTests.cs
+++ b/backend/FlashIdBackend/tests/InstitutionValidatorTests.cs
@@ -1,0 +1,102 @@
+using Application.Common.Validation;
+using Application.Features.Institutions.DTOs;
+using Application.Features.Institutions.Exceptions;
+
+namespace tests;
+
+public class InstitutionValidatorTests
+{
+    private static RegisterInstitutionRequestDto ValidRequest() => new()
+    {
+        Name = "Home Affairs Johannesburg",
+        VerificationNumber = "HA-JHB-2026-001",
+        AdminId = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_DoesNotThrow()
+    {
+        var ex = Record.Exception(() => InstitutionValidator.Validate(ValidRequest()));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Validate_NameEmpty_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.Name = "";
+
+        var ex = Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+
+        Assert.Contains("name", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_NameWhitespace_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.Name = "   ";
+
+        Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+    }
+
+    [Fact]
+    public void Validate_NameTooLong_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.Name = new string('A', 257);
+
+        var ex = Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+
+        Assert.Contains("256", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_VerificationNumberEmpty_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.VerificationNumber = "";
+
+        var ex = Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+
+        Assert.Contains("Verification", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_VerificationNumberWhitespace_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.VerificationNumber = "   ";
+
+        Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+    }
+
+    [Fact]
+    public void Validate_VerificationNumberTooLong_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.VerificationNumber = new string('V', 101);
+
+        var ex = Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+
+        Assert.Contains("100", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AdminIdEmpty_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.AdminId = Guid.Empty;
+
+        var ex = Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+
+        Assert.Contains("admin", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,244 @@
+# FlashID Testing Guide
+**Tech Titans · COS 301 Capstone 2026**
+
+---
+
+## Overview
+
+FlashID uses two separate testing stacks:
+
+- **Backend** — xUnit (C#) for unit and integration tests
+- **Frontend** — Jest + React Testing Library (TypeScript) for unit and component tests
+- **E2E** — Cypress or Playwright (planned after Demo 1)
+
+---
+
+## Test Types Defined
+
+### Unit Test
+Tests a single function, class, or component in complete isolation. All external dependencies (database, API, other services) are mocked. Runs fast with no network or DB access.
+
+### Component Test
+Tests a React component in isolation using a fake browser environment (jsdom). Does not make real HTTP calls. The component may use React Query hooks but mutations/queries never actually fire against a real backend. This is what `register-institution-form.test.tsx` is — a component test, not an integration test.
+
+### Integration Test
+Tests multiple real layers working together. For the backend this means hitting a real database. For the frontend this means a real running backend receives the HTTP request. No mocking of the actual system under test.
+
+### E2E Test
+Tests the full application in a real browser with a real backend and database. Simulates a real user clicking through flows.
+
+---
+
+## Backend Unit Tests
+
+### Stack
+- Framework: xUnit v3
+- Project: `backend/FlashIdBackend/tests/`
+- Run command:
+```bash
+cd backend/FlashIdBackend/tests
+dotnet test
+```
+
+### Folder Structure
+backend/FlashIdBackend/tests/
+├── tests.csproj
+├── xunit.runner.json
+├── CitizenRegistrationValidatorTests.cs
+└── InstitutionValidatorTests.cs
+
+### What to Test
+- **Validators** — every validation rule (empty, too long, invalid format, valid input)
+- **Services** — business logic with mocked DbContext
+- **Controllers** — HTTP responses for success and error cases
+
+### Naming Convention
+{ClassName}Tests.cs
+
+### Test Pattern
+One `ValidRequest()` helper, one `[Fact]` per rule:
+
+```csharp
+public class InstitutionValidatorTests
+{
+    private static RegisterInstitutionRequestDto ValidRequest() => new()
+    {
+        Name = "Home Affairs JHB",
+        VerificationNumber = "HA-JHB-001",
+        AdminId = Guid.NewGuid(),
+    };
+
+    [Fact]
+    public void Validate_ValidRequest_DoesNotThrow()
+    {
+        var ex = Record.Exception(() => InstitutionValidator.Validate(ValidRequest()));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Validate_NameEmpty_ThrowsInvalidRequest()
+    {
+        var req = ValidRequest();
+        req.Name = "";
+        Assert.Throws<InvalidInstitutionRequestException>(
+            () => InstitutionValidator.Validate(req));
+    }
+}
+```
+
+### Rules
+- One test file per class
+- One `[Fact]` per rule or scenario
+- Always include a "valid request does not throw" test
+- Method names follow: `MethodName_Condition_ExpectedResult`
+- No real database calls in unit tests — mock all dependencies
+
+---
+
+## Backend Integration Tests
+
+> Setup required — planned after Demo 1.
+
+Backend integration tests will test the full service → database flow using a real SQL Server test database.
+
+### Planned Setup
+- Add `Infrastructure` project reference to `tests.csproj`
+- Add EF Core + SQL Server packages to test project
+- Add a test connection string pointing to a separate `FlashIdTestDb`
+- Write tests that seed data, call the service, and assert DB state
+
+### Planned Test Coverage
+- `InstitutionService.RegisterInstitutionAsync` — institution created in DB, audit log written
+- `InstitutionService.GetAllInstitutionsAsync` — returns all seeded institutions
+- `AuthService.LoginAsync` — returns valid JWT for correct credentials, throws for wrong password
+
+### Naming Convention
+{ClassName}IntegrationTests.cs
+
+---
+
+## Frontend Unit and Component Tests
+
+### Stack
+- Framework: Jest + React Testing Library
+- Run command (from `web/` folder):
+```bash
+cd web
+npx jest --coverage
+```
+
+### Folder Structure
+Tests live in a `test/` folder next to the file being tested:
+src/components/organisms/register-institution-form/
+├── register-institution-form.tsx
+└── test/
+└── register-institution-form.test.tsx
+src/components/atoms/button/
+├── button.tsx
+└── test/
+└── button.test.tsx
+src/services/institution-service/
+├── institution-service.ts
+└── test/
+└── institution-service.test.ts
+
+### What to Test
+
+**Components** — rendering and user interactions:
+- Does it render the correct elements?
+- Does it respond correctly to user input?
+- Does it show the correct state changes?
+
+**Services** — DTOs, models, and URL builders:
+- Does the DTO map form values to backend field names correctly?
+- Does the model map backend response to frontend shape correctly?
+- Are URLs built correctly?
+
+**Config** — navigation and page headers:
+- Do all nav items have non-empty hrefs?
+- Are required items present in each portal's nav?
+
+### Naming Convention
+{filename}.test.tsx   (for React components)
+{filename}.test.ts    (for services, config, utils)
+
+### Test Pattern for Components
+Render, query, assert:
+
+```tsx
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByText('Click me')).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = jest.fn()
+    render(<Button onClick={onClick}>Go</Button>)
+    await user.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+### Components Using React Query
+Any component using `useQuery` or `useMutation` must be wrapped with `QueryClientProvider`:
+
+```tsx
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  Wrapper.displayName = 'TestWrapper'
+  return Wrapper
+}
+
+render(<MyComponent />, { wrapper: createWrapper() })
+```
+
+Note: wrapping with `QueryClientProvider` does NOT make a test an integration test. The mutation/query function never fires against a real backend — this is still a component unit test.
+
+### Rules
+- Test files live in `test/` next to the component
+- Use `screen.getByRole` over `getByTestId` where possible
+- Use `userEvent` for simulating user interactions
+- Never make real HTTP calls in unit tests — mock axios or use msw
+- Components using `useQuery` or `useMutation` must be wrapped with `QueryClientProvider`
+
+---
+
+## Frontend E2E Tests
+
+> Planned after Demo 1.
+
+E2E tests simulate real user flows in a real browser with a real running backend and database.
+
+### Planned Stack
+- Tool: Cypress or Playwright (TBD after Demo 1)
+
+### Planned Flows
+- GovernmentAdmin logs in → uploads institution → sees institution in list
+- Official logs in → onboards citizen → activation code generated
+- Citizen activates wallet → views credentials
+- Citizen generates QR code → verifier scans and verifies
+
+### Naming Convention
+{flow-name}.cy.ts   (Cypress)
+{flow-name}.spec.ts (Playwright)
+
+---
+
+## Coverage
+
+The CI runs coverage on every PR via Codecov.
+
+| Layer | Tool | Target |
+|---|---|---|
+| Frontend | Jest + Codecov | 95.54% patch coverage |
+| Backend | xUnit | No threshold set yet |
+
+Low coverage on new code will be flagged by Codecov on PRs. Add tests for new files in the same PR as the feature or in a dedicated testing PR immediately after.

--- a/web/src/components/organisms/register-institution-form/test/register-institution-form.test.tsx
+++ b/web/src/components/organisms/register-institution-form/test/register-institution-form.test.tsx
@@ -1,8 +1,19 @@
 /// <reference types="jest" />
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RegisterInstitutionForm } from '../register-institution-form'
+
+jest.mock('@/services/institution-service', () => ({
+  institutionService: {
+    register: jest.fn(),
+  },
+  RegisterInstitutionResponse: {},
+}))
+
+import { institutionService } from '@/services/institution-service'
+
+const mockRegister = institutionService.register as jest.Mock
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -16,6 +27,10 @@ const createWrapper = () => {
 }
 
 describe('RegisterInstitutionForm', () => {
+  beforeEach(() => {
+    mockRegister.mockReset()
+  })
+
   it('renders the form heading', () => {
     render(<RegisterInstitutionForm />, { wrapper: createWrapper() })
     expect(
@@ -36,6 +51,12 @@ describe('RegisterInstitutionForm', () => {
     const button = screen.getByRole('button', { name: /register/i })
     expect(button).toBeInTheDocument()
     expect(button).toHaveAttribute('type', 'submit')
+  })
+
+  it('register button is not disabled initially', () => {
+    render(<RegisterInstitutionForm />, { wrapper: createWrapper() })
+    const button = screen.getByRole('button', { name: /register/i })
+    expect(button).not.toBeDisabled()
   })
 
   it('allows typing in text fields', async () => {
@@ -67,5 +88,50 @@ describe('RegisterInstitutionForm', () => {
     await user.click(dropdownInput)
     await user.click(screen.getByRole('option', { name: /home affairs/i }))
     expect(dropdownInput).toHaveValue('Home Affairs')
+  })
+
+  it('shows success screen with API key after successful registration', async () => {
+    const user = userEvent.setup()
+    mockRegister.mockResolvedValue({
+      institutionId: 'inst-123',
+      name: 'Home Affairs JHB',
+      type: 'HomeAffairs',
+      apiKey: 'flashid_live_abc123',
+      apiKeyReference: 'ref-guid-123',
+      verificationNumber: 'HA-001',
+      createdAt: '2026-05-20T00:00:00Z',
+    })
+
+    render(<RegisterInstitutionForm />, { wrapper: createWrapper() })
+    await user.type(
+      screen.getByLabelText(/institution name/i),
+      'Home Affairs JHB'
+    )
+    await user.type(screen.getByLabelText(/verification number/i), 'HA-001')
+    await user.type(screen.getByLabelText(/admin id/i), 'admin-123')
+    await user.click(screen.getByRole('button', { name: /register/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/institution registered/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText('flashid_live_abc123')).toBeInTheDocument()
+  })
+
+  it('shows error toast on failed registration', async () => {
+    const user = userEvent.setup()
+    mockRegister.mockRejectedValue(new Error('Network error'))
+
+    render(<RegisterInstitutionForm />, { wrapper: createWrapper() })
+    await user.type(
+      screen.getByLabelText(/institution name/i),
+      'Home Affairs JHB'
+    )
+    await user.type(screen.getByLabelText(/verification number/i), 'HA-001')
+    await user.type(screen.getByLabelText(/admin id/i), 'admin-123')
+    await user.click(screen.getByRole('button', { name: /register/i }))
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalled()
+    })
   })
 })

--- a/web/src/services/institution-service/test/institution-service.test.ts
+++ b/web/src/services/institution-service/test/institution-service.test.ts
@@ -1,0 +1,70 @@
+import { registerInstitutionDto } from '../institution-dto'
+import { institutionModel } from '../institution-model'
+import institutionUrls from '../institution-urls'
+
+describe('registerInstitutionDto', () => {
+  it('maps HomeAffairs type to 0', () => {
+    const result = registerInstitutionDto({
+      institutionName: 'Home Affairs JHB',
+      institutionType: 'HomeAffairs',
+      verificationNumber: 'HA-001',
+      adminId: 'admin-123',
+    })
+    expect(result.type).toBe(0)
+  })
+
+  it('maps LicensingDepartment type to 1', () => {
+    const result = registerInstitutionDto({
+      institutionName: 'DLTC Pretoria',
+      institutionType: 'LicensingDepartment',
+      verificationNumber: 'DLTC-001',
+      adminId: 'admin-123',
+    })
+    expect(result.type).toBe(1)
+  })
+
+  it('maps form fields to backend field names correctly', () => {
+    const result = registerInstitutionDto({
+      institutionName: 'Home Affairs JHB',
+      institutionType: 'HomeAffairs',
+      verificationNumber: 'HA-001',
+      adminId: 'admin-guid-123',
+    })
+    expect(result.name).toBe('Home Affairs JHB')
+    expect(result.verificationNumber).toBe('HA-001')
+    expect(result.adminId).toBe('admin-guid-123')
+  })
+})
+
+describe('institutionModel', () => {
+  it('maps backend response to frontend model correctly', () => {
+    const backendData = {
+      institutionId: 'inst-123',
+      name: 'Home Affairs JHB',
+      type: 'HomeAffairs',
+      apiKey: 'flashid_live_abc123',
+      apiKeyReference: 'ref-guid-123',
+      verificationNumber: 'HA-001',
+      createdAt: '2026-05-20T00:00:00Z',
+    }
+    const result = institutionModel(backendData)
+    expect(result.institutionId).toBe('inst-123')
+    expect(result.name).toBe('Home Affairs JHB')
+    expect(result.apiKey).toBe('flashid_live_abc123')
+    expect(result.verificationNumber).toBe('HA-001')
+  })
+})
+
+describe('institutionUrls', () => {
+  it('register url contains correct path', () => {
+    expect(institutionUrls.register()).toContain('/api/institutions/register')
+  })
+
+  it('getAll url contains correct path', () => {
+    expect(institutionUrls.getAll()).toContain('/api/institutions')
+  })
+
+  it('getById url contains institution id', () => {
+    expect(institutionUrls.getById('inst-123')).toContain('inst-123')
+  })
+})


### PR DESCRIPTION
## Summary
Adds unit and component tests for the institution feature and a TESTING.md guide for the whole team.
Changes

Documentation
- docs/TESTING.md-documents how unit, component, integration and E2E tests should be written across the project, including patterns, folder structure, naming conventions and coverage expectations

 Backend Unit Tests
- InstitutionValidatorTests.cs-8 xUnit tests covering all validation rules (empty name, name too long, empty verification number, verification number too long, empty admin ID, valid request)

 Frontend Unit Tests
- institution-service.test.ts- 7 Jest tests for the institution service DTO mapping, model mapping, and URL functions with 100% coverage
- register-institution-form.test.tsx- updated with 8 tests including success screen display, API key visibility, error handling, and button state 

Test Results
- Backend: 20 tests passing (11 citizen + 8 institution validator + 1 placeholder)
- Frontend: all test suites passing

 Notes
- Integration and E2E tests are documented in TESTING.md and planned for a future PR after Demo 1