### PR TITLE
Fix/quick test script fix

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Build
         run: dotnet build ./backend/FlashIdBackend --no-restore --configuration Release
 
+      - name: Restore dependencies
+        run: |
+          dotnet restore ./backend/FlashIdBackend
+          dotnet tool restore --tool-manifest ./backend/FlashIdBackend/.config/dotnet-tools.json
+
       - name: Run tests with coverage
-        run: dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura
+        run: |
+         dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura --results-directory ./backend/TestResults
+         dotnet tool run reportgenerator -reports:"./backend/TestResults/**/*.cobertura.xml" -targetdir:"./backend/CoverageReport" -reporttypes:"Html;TextSummary"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,20 +24,12 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore ./backend/FlashIdBackend
-
+          
       - name: Build
         run: dotnet build ./backend/FlashIdBackend --no-restore --configuration Release
 
-      - name: Restore dependencies
-        run: |
-          dotnet restore ./backend/FlashIdBackend
-          dotnet tool restore --tool-manifest ./backend/FlashIdBackend/.config/dotnet-tools.json
-
       - name: Run tests with coverage
-        run: |
-         dotnet tool restore --tool-manifest ./backend/FlashIdBackend/.config/dotnet-tools.json
-         dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura --results-directory ./backend/TestResults
-         dotnet tool run reportgenerator -reports:"./backend/TestResults/**/*.cobertura.xml" -targetdir:"./backend/CoverageReport" -reporttypes:"Html;TextSummary"
+        run: dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura --results-directory ./backend/TestResults
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Build
         run: dotnet build ./backend/FlashIdBackend --no-restore --configuration Release
 
-      - name: Run tests
-        run: dotnet test ./backend/FlashIdBackend --no-build --configuration Release --results-directory ./coverage
+      - name: Run tests with coverage
+        run: dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          directory: ./coverage
+          files: ./backend/TestResults/**/*.cobertura.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
+         dotnet tool restore --tool-manifest ./backend/FlashIdBackend/.config/dotnet-tools.json
          dotnet test ./backend/FlashIdBackend --no-build --configuration Release --coverage --coverage-output-format cobertura --results-directory ./backend/TestResults
          dotnet tool run reportgenerator -reports:"./backend/TestResults/**/*.cobertura.xml" -targetdir:"./backend/CoverageReport" -reporttypes:"Html;TextSummary"
 

--- a/backend/FlashIdBackend/.config/dotnet-tools.json
+++ b/backend/FlashIdBackend/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.10",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/backend/FlashIdBackend/tests/tests.csproj
+++ b/backend/FlashIdBackend/tests/tests.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>tests</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!-- <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport> -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/TESTING.md
+++ b/backend/TESTING.md
@@ -1,0 +1,47 @@
+# Backend Testing & Coverage Guide
+
+Before running backend tests, ensure you have this installed:
+
+- ReportGenerator (for readable coverage reports):
+```bash
+  dotnet tool install --global dotnet-reportgenerator-globaltool
+```
+
+---
+
+## Running Tests
+
+### Run tests only (w/o coverage report)
+```bash
+pnpm test:backend
+```
+
+### Run tests with coverage report
+```bash
+pnpm test:backend:coverage
+```
+
+## Viewing Coverage Report
+
+After running testing with coverage, open human readable report at:
+```
+"./backend/CoverageReport/index.html"
+```
+
+## Codecov
+### `TestResults/*.cobertura.xml`
+This is the machine-readable coverage file generated during a coverage run. It is in the [Cobertura](https://cobertura.github.io/cobertura/) XML format, which is a standard coverage report format supported by most CI tools. This file is what gets uploaded to Codecov and is also used by **reportgenerator** to produce the human-readable HTML report.
+
+## Troubleshooting
+
+**reportgenerator not found**
+```bash
+dotnet tool install --global dotnet-reportgenerator-globaltool
+```
+
+**Tests not found / zero tests ran**
+```bash
+pnpm clean:backend
+pnpm install:backend
+pnpm test:backend:coverage
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,9 +6,11 @@
     "restore": "dotnet restore FlashIdBackend/FlashIdBackend.sln",
     "dev": "dotnet watch run --project FlashIdBackend/Presentation/Presentation.csproj",
     "start": "dotnet run --project FlashIdBackend/Presentation/Presentation.csproj",
+    "clean": "dotnet clean FlashIdBackend/FlashIdBackend.sln",
     "build": "dotnet build FlashIdBackend/Presentation/Presentation.csproj",
     "type-check": "dotnet build FlashIdBackend/FlashIdBackend.sln",
-    "test": "dotnet test FlashIdBackend/FlashIdBackend.sln",
+    "test": "dotnet test --solution FlashIdBackend/FlashIdBackend.sln",
+    "test:coverage": "dotnet test --solution FlashIdBackend/FlashIdBackend.sln --coverage --coverage-output-format cobertura --results-directory ./TestResults",
     "format": "dotnet format FlashIdBackend/",
     "lint": "dotnet format --verify-no-changes FlashIdBackend/"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,14 +3,14 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "restore": "dotnet restore FlashIdBackend/FlashIdBackend.sln",
+    "restore": "dotnet restore FlashIdBackend/FlashIdBackend.sln && dotnet tool restore --tool-manifest FlashIdBackend/.config/dotnet-tools.json",
     "dev": "dotnet watch run --project FlashIdBackend/Presentation/Presentation.csproj",
     "start": "dotnet run --project FlashIdBackend/Presentation/Presentation.csproj",
     "clean": "dotnet clean FlashIdBackend/FlashIdBackend.sln",
     "build": "dotnet build FlashIdBackend/Presentation/Presentation.csproj",
     "type-check": "dotnet build FlashIdBackend/FlashIdBackend.sln",
     "test": "dotnet test --solution FlashIdBackend/FlashIdBackend.sln",
-    "test:coverage": "dotnet test --solution FlashIdBackend/FlashIdBackend.sln --coverage --coverage-output-format cobertura --results-directory ./TestResults",
+    "test:coverage": "dotnet test --solution FlashIdBackend/FlashIdBackend.sln --coverage --coverage-output-format cobertura --results-directory ./TestResults && reportgenerator -reports:\"./TestResults/**/*.cobertura.xml\" -targetdir:\"./CoverageReport\" -reporttypes:\"Html;TextSummary\"",
     "format": "dotnet format FlashIdBackend/",
     "lint": "dotnet format --verify-no-changes FlashIdBackend/"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "packageManager": "pnpm@9.15.9",
   "scripts": {
-    "install:all": "pnpm install && pnpm --filter ./web install && pnpm --filter ./backend install",
+    "install:all": "pnpm install && pnpm --filter ./web install && pnpm --filter ./backend restore",
     "install:web": "pnpm --filter ./web install",
     "start:web": "pnpm --filter ./web start",
     "build:web": "pnpm --filter ./web build",
@@ -16,17 +16,21 @@
     "test:web:coverage": "pnpm --filter ./web run test:coverage",
     "postinstall": "lefthook install",
 
-    "install:backend": "pnpm --filter ./backend install",
+    "install:backend": "pnpm --filter ./backend restore",
     "start:backend": "pnpm --filter ./backend start",
+    "clean:backend": "pnpm --filter ./backend run clean",
     "build:backend": "pnpm --filter ./backend run build",
     "dev:backend": "pnpm --filter ./backend run dev",
     "lint:backend": "pnpm --filter ./backend run lint",
     "format:backend": "pnpm --filter ./backend run format",
     "type-check:backend": "pnpm --filter ./backend run type-check",
+    "test:backend": "pnpm --filter ./backend run test",
+    "test:backend:coverage": "pnpm --filter ./backend run test:coverage",
     
     "dev": "concurrently --kill-others-on-fail \"pnpm --filter ./web dev\" \"pnpm --filter ./backend run dev\"",
     "build": "pnpm install && pnpm --filter ./backend run build && pnpm --filter ./web build",
-    "test": "pnpm --filter ./backend run test",
+    "test": "pnpm --filter ./web run test && pnpm --filter ./backend run test",
+    "test:coverage": "pnpm --filter ./web run test:coverage && pnpm --filter ./backend run test:coverage",
     "format": "pnpm --filter ./backend run format && pnpm --filter ./web format",
     "lint": "pnpm --filter ./backend run lint && pnpm --filter ./web lint",
     "type-check": "pnpm --filter ./backend run type-check && pnpm --filter ./web type-check"


### PR DESCRIPTION
What i did:

- Replaced xunit.v3.mtp-v2 with xunit.v3 and removed 
- Added Microsoft.Testing.Extensions.CodeCoverage 18.0.4 for MTP-native coverage collection
- Fixed the backend testing scripts 
- Added dotnet-reportgenerator-globaltool to a dotnet-tools.json manifest so teammates can restore it automatically
- Updated backend.yml to use the new coverage flags and tool restore step so CI collects and uploads coverage to Codecov
- Added TESTING.md explaining how to run tests and view the HTML coverage report. PLEASE check it out.